### PR TITLE
README.md file content and reformatting YAML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ The `pet-store-example.yml` sample document serves to assist developers with syn
 
         # Begin your HTTP Methods specification from this line downwards
 ```
-- Depending on the amount of servers required, developers can specify the URL for different environments during stages of development. Each URL path shares the same key name `url` due to the preceeding `-` symbol denoting array types. **NOTE: Utilizing `server` syntax may be incompatible with Swagger 2.0 version**. 
-If working with newer syntax, consider indicating the version at the top of the file as OpenAPI version 3.0.x e.g. `openapi: 3.0.0`.  
+- Depending on the amount of servers required, developers can specify the URL for different environments during stages of development. Each URL path shares the same key name `url` due to the preceeding `-` symbol denoting array types. 
 
 ```
 servers:
@@ -58,6 +57,10 @@ servers:
   - url: http://localhost:5000/api/v1/OrbitalAdmin
     description: Basepath HTTP URL when launching an Orbital instance for development
 ```
-- If working on a local text editor, for added confirmation of correct syntax, indentation, etc. copy/paste your working file into the Swagger Editor to confirm the specifications are readable YAML/JSON format. URL: https://editor.swagger.io/
+
+**NOTE: Utilizing `servers` key words may be incompatible with Swagger 2.0 version**. 
+If working with newer syntax, consider indicating the version at the top of the file as OpenAPI version 3.0.x e.g. `openapi: 3.0.0`.  
+
+- If working on a local text editor, for added confirmation of correct syntax, indentation, etc. copy/paste your working file into the **Swagger Editor** to confirm the specifications are readable YAML/JSON format. URL: https://editor.swagger.io/
 
 **For further information on troubleshooting OpenAPI documents, please refer to the Swagger OpenAPI documentation here: https://swagger.io/specification/**

--- a/README.md
+++ b/README.md
@@ -24,7 +24,40 @@ Recommended Text Editors:
 
 For Orbital, a sample OpenAPI document in YAML can be located within the `Orbital-Demo` repository accessible via: https://github.com/FociSolutions/Orbital-Demo/blob/develop/Samples/pet-store-example.yml.
 
-The `pet-store-example.yml` sample document serves to assist developers with syntax, indentation formatting and pathing specifications. For further information on creating OpenAPI documents, please refer to the Swagger OpenAPI documentation here: https://swagger.io/specification/
+The `pet-store-example.yml` sample document serves to assist developers with syntax, indentation formatting and pathing specifications. **For further information on creating OpenAPI documents, please refer to the Swagger OpenAPI documentation here: https://swagger.io/specification/**
 
 
 ### Orbital Considerations 
+- Currently compatible with Swagger 2.0. Ensure the version at the top of the document specifies `swagger: '2.0'`.
+- When creating the mock definition from the OpenAPI specifications, the parser transcribes the verbs into specific JSON schemas, based on the path names given. 
+- Default scenarios are generated based off the specific paths given.
+
+
+### Troubleshooting
+- As OpenAPI YAML formats work on a `key: value` structure, ensure the keys are unique for each path. If different HTTP methods rely on the same path, you can nest them within the path name. e.g. PUT, DELETE, GET by id are dependent on a `petId` parameter in the URL therefore these methods can be nested with the `/pets/{petId}` path.
+- If different HTTP methods rely on the same `parameters`, you can declare them globally under the path name, and will be utilized across all endpoints. 
+```
+/pets/{petId}:
+      parameters: 
+          - name: petId
+            in: path
+            required: true
+            description: The id of the pet to retrieve
+            type: string
+
+        # Begin your HTTP Methods specification from this line downwards
+```
+- Depending on the amount of servers required, developers can specify the URL for different environments during stages of development. Each URL path shares the same key name `url` due to the preceeding `-` symbol denoting array types. **NOTE: Utilizing `server` syntax may be incompatible with Swagger 2.0 version**. 
+If working with newer syntax, consider indicating the version at the top of the file as OpenAPI version 3.0.x e.g. `openapi: 3.0.0`.  
+
+```
+servers:
+  - url: https://localhost:5001/api/v1/OrbitalAdmin
+    description: Basepath HTTPS URL when launching an Orbital instance for development
+
+  - url: http://localhost:5000/api/v1/OrbitalAdmin
+    description: Basepath HTTP URL when launching an Orbital instance for development
+```
+- If working on a local text editor, for added confirmation of correct syntax, indentation, etc. copy/paste your working file into the Swagger Editor to confirm the specifications are readable YAML/JSON format. URL: https://editor.swagger.io/
+
+**For further information on troubleshooting OpenAPI documents, please refer to the Swagger OpenAPI documentation here: https://swagger.io/specification/**

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # Orbital-Demo
 Sample project demonstrating expected usage of Orbital within a development team
+
+
+----
+
+## Orbital OpenApi Specification
+
+### Introduction
+The OpenAPI Specification (OAS) defines a standard, language-agnostic interface to RESTful APIs which allows both developers and computers to discover and understand the capabilities of the service without access to source code, documentation, or through network traffic inspection. When properly defined, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. 
+
+src: https://swagger.io/specification/ 
+
+The output of an OpenAPI Specification is a document or documents that define the API. The format is usually `YAML` or `JSON`, however YAML is the preferred standard due to its human-readable syntax. 
+
+
+
+### Creating an OpenAPI document 
+Recommended Text Editors:
+- VSCode IDE with 'YAML' (Red Hat) extension 
+- Swagger Editor: https://editor.swagger.io/
+- Sublime with 'Pretty YAML' plugin
+
+
+For Orbital, a sample OpenAPI document in YAML can be located within the `Orbital-Demo` repository accessible via: https://github.com/FociSolutions/Orbital-Demo/blob/develop/Samples/pet-store-example.yml.
+
+The `pet-store-example.yml` sample document serves to assist developers with syntax, indentation formatting and pathing specifications. For further information on creating OpenAPI documents, please refer to the Swagger OpenAPI documentation here: https://swagger.io/specification/
+
+
+### Orbital Considerations 

--- a/Samples/pet-store-example.yml
+++ b/Samples/pet-store-example.yml
@@ -18,7 +18,7 @@ basePath: /v1
 schemes:
   - http
   - https
-  
+
 consumes: 
   - application/json
 produces:
@@ -39,7 +39,7 @@ paths:
          type: integer
          format: int32
      responses: 
-        "200":
+        200:
          description: A paged array of pets
          headers: 
           x-next: 
@@ -57,7 +57,7 @@ paths:
         tags: 
           - pets
         responses: 
-          "201":
+          201:
             description: Null response
           default: 
             description: Unexpected error while creating a new pet
@@ -76,7 +76,7 @@ paths:
         tags: 
         - pets
         responses: 
-          "200": 
+          200: 
             description: Expected response to a valid request
             schema:  
               $ref: '#/definitions/Pets'
@@ -91,7 +91,7 @@ paths:
         tags:
           - pets
         responses:
-          "200":
+          200:
             description: Updated or created successfully
             schema:  
               $ref: '#/definitions/Pets'
@@ -105,7 +105,7 @@ paths:
         tags:
           - pets
         responses:
-          "200":
+          200:
             description: Deleted pet successfully
             schema:  
               $ref: '#/definitions/Pets'
@@ -116,7 +116,7 @@ paths:
 
 definitions:
   Pet:
-    type: "object"
+    type: object
     required:
       - id
       - name
@@ -128,12 +128,14 @@ definitions:
         type: string
       tag:
         type: string
+      attributes:
+        type: object
   Pets:
     type: array
     items:
       $ref: '#/definitions/Pet'
   Error:
-    type: "object"
+    type: object
     required:
       - code
       - message


### PR DESCRIPTION
- Added readme content to root README.md file with sections - introduction, Orbital guidelines, troubleshooting tips, URL links
- Refactored Pet-Store YAML for cleanup and syntax congruency 